### PR TITLE
Fix invalid YAML structure in render blueprint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -29,16 +29,8 @@ services:
       python -m pip install --no-cache-dir -r requirements.txt
       python manage.py migrate --noinput --fake-initial
       python manage.py collectstatic --noinput
-      python - <<'PY'
-import pathlib, py_compile, sys
-bad = []
-for p in pathlib.Path('.').rglob('*.py'):
-    try: py_compile.compile(str(p), doraise=True)
-    except Exception as e:
-        bad.append(f"{p}: {e}")
-if bad:
-    print("\n".join(bad)); sys.exit(1)
-PY
+      # Compile all Python files to detect syntax errors
+      python -m compileall -q .
 
 
     startCommand: >


### PR DESCRIPTION
## Summary
- replace malformed heredoc in `render.yaml` with a compileall invocation to fix YAML parsing

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_68b0b8f7b5dc83308dbb5fa1d84cab3d