### PR TITLE
Fix asset/client migration for SQLite and clean up nav URLs

### DIFF
--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+application = get_wsgi_application()

--- a/core/migrations/0002_asset_client_fk.py
+++ b/core/migrations/0002_asset_client_fk.py
@@ -1,45 +1,52 @@
 from django.db import migrations
 
 
+def ensure_client_fk(apps, schema_editor):
+    """Ensure legacy Asset rows have a client FK.
+
+    The original deployment used raw SQL against PostgreSQL. SQLite, used for
+    local development and tests, chokes on ``IF NOT EXISTS`` clauses. This
+    migration now runs the SQL only when the database vendor is PostgreSQL and
+    becomes a no-op elsewhere.
+    """
+
+    if schema_editor.connection.vendor != "postgresql":  # pragma: no cover - exercised in CI
+        return
+
+    schema_editor.execute(
+        """
+        ALTER TABLE IF EXISTS core_asset
+        ADD COLUMN IF NOT EXISTS client_id integer;
+        """
+    )
+    schema_editor.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.table_constraints
+                WHERE table_name='core_asset' AND constraint_name='core_asset_client_id_fk'
+            ) THEN
+                ALTER TABLE core_asset
+                    ADD CONSTRAINT core_asset_client_id_fk
+                    FOREIGN KEY (client_id) REFERENCES core_client(id)
+                    DEFERRABLE INITIALLY DEFERRED;
+            END IF;
+        END
+        $$;
+        """
+    )
+    schema_editor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS core_asset_client_id_idx
+        ON core_asset (client_id);
+        """
+    )
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("core", "0001_initial"),
     ]
 
-    operations = [
-        # 1) Add column if it's missing
-        migrations.RunSQL(
-            sql="""
-                ALTER TABLE IF EXISTS core_asset
-                ADD COLUMN IF NOT EXISTS client_id integer;
-            """,
-            reverse_sql=migrations.RunSQL.noop,
-        ),
-        # 2) Add FK (idempotent)
-        migrations.RunSQL(
-            sql="""
-            DO $$
-            BEGIN
-                IF NOT EXISTS (
-                    SELECT 1 FROM information_schema.table_constraints
-                    WHERE table_name='core_asset' AND constraint_name='core_asset_client_id_fk'
-                ) THEN
-                    ALTER TABLE core_asset
-                        ADD CONSTRAINT core_asset_client_id_fk
-                        FOREIGN KEY (client_id) REFERENCES core_client(id)
-                        DEFERRABLE INITIALLY DEFERRED;
-                END IF;
-            END
-            $$;
-            """,
-            reverse_sql=migrations.RunSQL.noop,
-        ),
-        # 3) Helpful index
-        migrations.RunSQL(
-            sql="""
-                CREATE INDEX IF NOT EXISTS core_asset_client_id_idx
-                ON core_asset (client_id);
-            """,
-            reverse_sql=migrations.RunSQL.noop,
-        ),
-    ]
+    operations = [migrations.RunPython(ensure_client_fk, migrations.RunPython.noop)]

--- a/render.yaml
+++ b/render.yaml
@@ -29,16 +29,8 @@ services:
       python -m pip install --no-cache-dir -r requirements.txt
       python manage.py migrate --noinput --fake-initial
       python manage.py collectstatic --noinput
-      python - <<'PY'
-import pathlib, py_compile, sys
-bad = []
-for p in pathlib.Path('.').rglob('*.py'):
-    try: py_compile.compile(str(p), doraise=True)
-    except Exception as e:
-        bad.append(f"{p}: {e}")
-if bad:
-    print("\n".join(bad)); sys.exit(1)
-PY
+      # Compile all Python files to detect syntax errors
+      python -m compileall -q .
 
 
     startCommand: >

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,9 +18,9 @@
         <nav class="nav">
           {% if user.is_authenticated %}
             <a href="/dashboard/">Dashboard</a>
-            <a href="/work/new">Add Labor &amp; Equipment</a>
-            <a href="/materials/new">Add Materials</a>
-            <a href="/payments/new">Record Payment</a>
+            <a href="/work/new/">Add Labor &amp; Equipment</a>
+            <a href="/materials/new/">Add Materials</a>
+            <a href="/payments/new/">Record Payment</a>
             {% if user.is_staff %}
               <a href="/admin/">Admin</a>
             {% endif %}


### PR DESCRIPTION
## Summary
- prevent 0002_asset_client_fk migration from running PostgreSQL-specific SQL on SQLite
- add trailing slashes to quick-action navigation links
- provide a WSGI entry point so Django can run under WSGI servers

## Testing
- `python manage.py migrate --noinput`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_68b0b8f7b5dc83308dbb5fa1d84cab3d