### PR TITLE
Fix admin 500 by installing timezone data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ whitenoise[brotli]>=6.6
 gunicorn>=21.2
 uvicorn[standard]>=0.30
 python-dotenv>=1.0
+tzdata>=2024.1


### PR DESCRIPTION
## Summary
- include `tzdata` so Django can load `America/New_York` timezone and serve admin pages without 500 errors

## Testing
- `python manage.py check`
- `python -m pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b0c44669608330976937d31e2bde77