### PR TITLE
Handle asset client FK migration across all DB backends

### DIFF
--- a/core/migrations/0002_asset_client_fk.py
+++ b/core/migrations/0002_asset_client_fk.py
@@ -1,47 +1,51 @@
-from django.db import migrations
+from django.db import migrations, models
 
 
 def ensure_client_fk(apps, schema_editor):
-    """Ensure legacy Asset rows have a client FK.
+    """Ensure legacy Asset rows have a client FK across all backends.
 
-    The original deployment used raw SQL against PostgreSQL. SQLite, used for
-    local development and tests, chokes on ``IF NOT EXISTS`` clauses. This
-    migration now runs the SQL only when the database vendor is PostgreSQL and
-    becomes a no-op elsewhere.
+    The original migration used PostgreSQL-specific SQL with ``IF NOT EXISTS``
+    clauses that fail on SQLite.  Using the schema editor allows Django to
+    handle the appropriate SQL for the active backend.
     """
 
-    if schema_editor.connection.vendor != "postgresql":  # pragma: no cover - exercised in CI
+    connection = schema_editor.connection
+    table_name = "core_asset"
+
+    with connection.cursor() as cursor:
+        column_names = {
+            c.name for c in connection.introspection.get_table_description(cursor, table_name)
+        }
+
+    if "client_id" in column_names:
         return
 
-    schema_editor.execute(
-        """
-        ALTER TABLE IF EXISTS core_asset
-        ADD COLUMN IF NOT EXISTS client_id integer;
-        """
+    Client = apps.get_model("core", "Client")
+    Asset = apps.get_model("core", "Asset")
+    field = models.ForeignKey(
+        Client, null=True, blank=True, related_name="assets", on_delete=models.CASCADE
     )
-    schema_editor.execute(
-        """
-        DO $$
-        BEGIN
-            IF NOT EXISTS (
-                SELECT 1 FROM information_schema.table_constraints
-                WHERE table_name='core_asset' AND constraint_name='core_asset_client_id_fk'
-            ) THEN
-                ALTER TABLE core_asset
-                    ADD CONSTRAINT core_asset_client_id_fk
-                    FOREIGN KEY (client_id) REFERENCES core_client(id)
-                    DEFERRABLE INITIALLY DEFERRED;
-            END IF;
-        END
-        $$;
-        """
-    )
-    schema_editor.execute(
-        """
-        CREATE INDEX IF NOT EXISTS core_asset_client_id_idx
-        ON core_asset (client_id);
-        """
-    )
+    field.set_attributes_from_name("client")
+    schema_editor.add_field(Asset, field)
+
+
+def remove_client_fk(apps, schema_editor):
+    """Reverse the ``ensure_client_fk`` operation."""
+
+    connection = schema_editor.connection
+    table_name = "core_asset"
+
+    with connection.cursor() as cursor:
+        column_names = {
+            c.name for c in connection.introspection.get_table_description(cursor, table_name)
+        }
+
+    if "client_id" not in column_names:
+        return
+
+    Asset = apps.get_model("core", "Asset")
+    field = Asset._meta.get_field("client")
+    schema_editor.remove_field(Asset, field)
 
 
 class Migration(migrations.Migration):
@@ -49,4 +53,4 @@ class Migration(migrations.Migration):
         ("core", "0001_initial"),
     ]
 
-    operations = [migrations.RunPython(ensure_client_fk, migrations.RunPython.noop)]
+    operations = [migrations.RunPython(ensure_client_fk, remove_client_fk)]


### PR DESCRIPTION
## Summary
- Refactor asset client foreign key migration to work on any database backend
- Add reverse operation to drop the client foreign key

## Testing
- `python manage.py migrate`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d0367b6c83308daefca71627bc4a