### PR TITLE
Use assets terminology on dashboard

### DIFF
--- a/templates/core/dashboard.html
+++ b/templates/core/dashboard.html
@@ -22,7 +22,7 @@
 </div>
 <div class="card">
 <h3 class="h3">Setup</h3>
-<p class="muted">Use <a href="/admin/">Admin</a> to add <strong>Clients</strong>, <strong>Jobs</strong>, <strong>Resources</strong>, and optional per‑job <strong>Rate Overrides</strong>.</p>
+<p class="muted">Use <a href="/admin/">Admin</a> to add <strong>Clients</strong>, <strong>Jobs</strong>, <strong>Assets</strong>, and optional per‑job <strong>Rate Overrides</strong>.</p>
 </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace "Resources" with "Assets" in dashboard setup instructions.
- Confirmed admin uses Asset naming in models and admin registration.

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d0376f04833085e3162d2d2dff41